### PR TITLE
State machine refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,66 @@
 # NASAPicOnSpring
 
-Telegram Bot on JAVA Spring which send you pics and explanation text 
+Telegram Bot on Kotlin (Koin DI) which send you pics and explanation text
 from NASA A Picture of A Day (APOD) using `https://apod.ellanan.com/api` [GitHub](https://github.com/ellanan/apod-api)
 
 Deployed serverless on Yandex Cloud platform. [Try](https://t.me/NASAPic_bot)
 
 ### Supported commands:
 - `/start`, `/help` - get bot description
-- `/give` - get today's post
+- `/today` - get today's post
 - `/random` - get random post
+- `/schedule` - toggle daily scheduled posts
+- `/translate` - toggle EN→RU translation
+- `YYYY-MM-DD` - get post for a specific date (no earlier than 1995-06-20)
 
 ### Deployment
 
 1. Install and configure yc CLI for your Yandex Cloud account.
 
-2. Modify and run yc CLI command to create serverless function: `yc serverless function create --name=java-function`
+2. Modify and run yc CLI command to create serverless functions:
+   ```
+   yc serverless function create --name=<function_name>
+   ```
+   Repeat for the timer function used by `/schedule`.
 
-3. Create `src.zip` archive with `src/` folder and `pom.xml` file.
+3. Create `src_kotlin_prod.zip` archive with `src/`, `build.gradle.kts`, and `settings.gradle.kts`:
+   ```
+   tar.exe -a -c -f src_kotlin_prod.zip src build.gradle.kts settings.gradle.kts
+   ```
 
-4. Modify and run yc CLI command to create serverless function version
+4. Modify and run yc CLI command to create the main serverless function version:
 ```
-yc serverless function version create `
-  --service-account-id <service_account_id> `
-  --function-name=java-function `
-  --runtime java21 `
-  --entrypoint space.maxkonkin.nasapicbot.web.Handler `
-  --memory 256m `
-  --execution-timeout 10s `
-  --environment "YA_API_TOKEN=Api-Key <your yandex API token>" ` 
-  --environment BOT_TOKEN=<your telegram bot token> `
-  --source-path ./src.zip
+yc serverless function version create ^
+  --service-account-id <service_account_id> ^
+  --function-id <function_id> ^
+  --runtime kotlin20 ^
+  --entrypoint space.maxkonkin.nasapicbot.web.Handler ^
+  --memory 2048m ^
+  --execution-timeout 15s ^
+  --environment "YA_API_TOKEN=Api-Key <your yandex API token>" ^
+  --environment BOT_TOKEN=<your telegram bot token> ^
+  --environment "DATABASE=<your ydb database path>" ^
+  --environment PROFILE=prod ^
+  --source-path ./src_kotlin_prod.zip
 ```
 
-5. Create a new message queue
+5. Deploy the timer function version (used for scheduled posts):
+```
+yc serverless function version create ^
+  --service-account-id <service_account_id> ^
+  --function-id <timer_function_id> ^
+  --runtime kotlin20 ^
+  --entrypoint space.maxkonkin.nasapicbot.web.TimerHandler ^
+  --memory 2048m ^
+  --execution-timeout 15s ^
+  --environment "YA_API_TOKEN=Api-Key <your yandex API token>" ^
+  --environment BOT_TOKEN=<your telegram bot token> ^
+  --environment "DATABASE=<your ydb database path>" ^
+  --environment PROFILE=prod ^
+  --source-path ./src_kotlin_prod.zip
+```
+
+6. Create a new message queue:
  - Install and configure the AWS CLI.
  - Run the following command in the terminal:
    `aws sqs create-queue \
@@ -45,7 +73,7 @@ yc serverless function version create `
                "QueueUrl": "<queue_url>"
             }`
 
-6. Modify and run yc CLI command to create trigger which automatically sends messages from queue to function:
+7. Modify and run yc CLI command to create trigger which automatically sends messages from queue to function:
 
 ```
 yc serverless trigger create message-queue \
@@ -58,7 +86,7 @@ yc serverless trigger create message-queue \
    --batch-cutoff 10s
 ```
 
-6. Create entry point for the queue by API Gateway service using Control panel
+8. Create entry point for the queue by API Gateway service using Control panel:
  - In the management console, select the folder where you want to create an API gateway.
  - In the list of services, select API Gateway.
  - Click Create API gateway.
@@ -87,4 +115,4 @@ paths:
   - Configure additional API gateway settings if needed.
   - Click Create.
 
-7. Set proper webhook adress for entry point by performing GET request: `https://api.telegram.org/bot<telegram bot token>/setWebhook?url=<URL of ApiGW entry point>/callback`
+9. Set proper webhook address for entry point by performing GET request: `https://api.telegram.org/bot<telegram bot token>/setWebhook?url=<URL of ApiGW entry point>/callback`

--- a/src/main/kotlin/space/maxkonkin/nasapicbot/model/BotCommand.kt
+++ b/src/main/kotlin/space/maxkonkin/nasapicbot/model/BotCommand.kt
@@ -1,0 +1,58 @@
+package space.maxkonkin.nasapicbot.model
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+sealed class BotCommand {
+    object Start     : BotCommand()
+    object Help      : BotCommand()
+    object Today     : BotCommand()
+    object Random    : BotCommand()
+    object Schedule  : BotCommand()
+    object Translate : BotCommand()
+    data class OnDate(val date: LocalDate) : BotCommand()
+    object InvalidDateRange  : BotCommand()
+    object InvalidDateFormat : BotCommand()
+    object Reply     : BotCommand()
+    object Unknown   : BotCommand()
+
+    companion object {
+        private val DATE_REGEX = Regex("\\d{4}-\\d{2}-\\d{2}")
+        private val APOD_START = LocalDate.of(1995, 6, 20)
+
+        fun parse(text: String, botName: String, isReply: Boolean): BotCommand {
+            val dateMatch = DATE_REGEX.find(text)
+            if (dateMatch != null) {
+                return try {
+                    val date = LocalDate.parse(dateMatch.value, DateTimeFormatter.ISO_LOCAL_DATE)
+                    when {
+                        date.isBefore(APOD_START) || date.isAfter(LocalDate.now()) -> InvalidDateRange
+                        else -> OnDate(date)
+                    }
+                } catch (_: DateTimeParseException) {
+                    InvalidDateFormat
+                }
+            }
+            val command = stripBotName(text, botName)
+            return when (command) {
+                "/start"     -> Start
+                "/help"      -> Help
+                "/today"     -> Today
+                "/random"    -> Random
+                "/schedule"  -> Schedule
+                "/translate" -> Translate
+                else         -> if (isReply) Reply else Unknown
+            }
+        }
+
+        private fun stripBotName(command: String, botName: String): String {
+            val atIndex = command.indexOf('@')
+            if (atIndex < 0) return command
+            return if (command.substring(atIndex + 1).equals(botName, ignoreCase = true))
+                command.substring(0, atIndex)
+            else
+                command
+        }
+    }
+}

--- a/src/main/kotlin/space/maxkonkin/nasapicbot/model/ScheduleState.kt
+++ b/src/main/kotlin/space/maxkonkin/nasapicbot/model/ScheduleState.kt
@@ -1,0 +1,13 @@
+package space.maxkonkin.nasapicbot.model
+
+enum class ScheduleState {
+    NONE,   // trigger не создан
+    ACTIVE, // trigger активен, рассылка идёт
+    PAUSED; // trigger на паузе
+
+    fun toggle(): ScheduleState = when (this) {
+        NONE   -> ACTIVE
+        ACTIVE -> PAUSED
+        PAUSED -> ACTIVE
+    }
+}

--- a/src/main/kotlin/space/maxkonkin/nasapicbot/model/User.kt
+++ b/src/main/kotlin/space/maxkonkin/nasapicbot/model/User.kt
@@ -5,7 +5,7 @@ import tech.ydb.table.result.ResultSetReader
 data class User(
     val chatId: Long,
     val name: String,
-    val isScheduled: Boolean,
+    val scheduleState: ScheduleState,
     val translateLangCode: LangCode,
     val triggerId: String? = null
 ) {
@@ -13,11 +13,15 @@ data class User(
         fun fromResultSet(resultSet: ResultSetReader): User {
             val chatId = resultSet.getColumn("chat_id").uint64
             val name = resultSet.getColumn("name").text
-            val isScheduled = resultSet.getColumn("is_scheduled").bool
+            val scheduleStateValue = resultSet.getColumn("schedule_state").value.asOptional()
+            val scheduleState = if (scheduleStateValue.isPresent)
+                ScheduleState.valueOf(scheduleStateValue.get().asData().text.uppercase())
+            else
+                ScheduleState.NONE
             val translateLangCode = LangCode.valueOf(resultSet.getColumn("translate_lang_code").text.uppercase())
             val triggerIdValue = resultSet.getColumn("trigger_id").value.asOptional()
             val triggerId = if (triggerIdValue.isPresent) triggerIdValue.get().asData().text else null
-            return User(chatId, name, isScheduled, translateLangCode, triggerId)
+            return User(chatId, name, scheduleState, translateLangCode, triggerId)
         }
     }
 }

--- a/src/main/kotlin/space/maxkonkin/nasapicbot/repository/UserRepository.kt
+++ b/src/main/kotlin/space/maxkonkin/nasapicbot/repository/UserRepository.kt
@@ -27,7 +27,7 @@ class UserRepository(
     override fun getById(id: Long): User? {
         val users = ArrayList<User>()
         entityManager.execute("DECLARE \$chat_id AS Uint64; " +
-                "SELECT chat_id, name, is_scheduled, translate_lang_code, trigger_id FROM ${config.ydbUserTable} " +
+                "SELECT chat_id, name, schedule_state, translate_lang_code, trigger_id FROM ${config.ydbUserTable} " +
                 "WHERE chat_id = \$chat_id",
             Params.of("\$chat_id", PrimitiveValue.newUint64(id)),
             ThrowingConsumer.unchecked<DataQueryResult, RuntimeException> { result ->
@@ -42,14 +42,14 @@ class UserRepository(
     override fun save(entity: User) {
         val query = "DECLARE \$chat_id AS Uint64;" +
                 "DECLARE \$name AS Utf8;" +
-                "DECLARE \$is_scheduled AS Bool;" +
+                "DECLARE \$schedule_state AS Utf8;" +
                 "DECLARE \$translate_lang_code AS Utf8;" +
-                "INSERT INTO ${config.ydbUserTable} (chat_id, name, is_scheduled, translate_lang_code) " +
-                "VALUES (\$chat_id, \$name, \$is_scheduled,  \$translate_lang_code)"
+                "INSERT INTO ${config.ydbUserTable} (chat_id, name, schedule_state, translate_lang_code) " +
+                "VALUES (\$chat_id, \$name, \$schedule_state, \$translate_lang_code)"
         val params = Params.of(
             "\$chat_id", PrimitiveValue.newUint64(entity.chatId),
             "\$name", PrimitiveValue.newText(entity.name),
-            "\$is_scheduled", PrimitiveValue.newBool(entity.isScheduled),
+            "\$schedule_state", PrimitiveValue.newText(entity.scheduleState.name),
             "\$translate_lang_code", PrimitiveValue.newText(entity.translateLangCode.code)
         )
         entityManager.execute(query, params)
@@ -58,15 +58,15 @@ class UserRepository(
     override fun update(entity: User) {
         val query = "DECLARE \$chat_id AS Uint64;" +
                 "DECLARE \$name AS Utf8;" +
-                "DECLARE \$is_scheduled AS Bool;" +
+                "DECLARE \$schedule_state AS Utf8;" +
                 "DECLARE \$translate_lang_code AS Utf8;" +
                 "DECLARE \$trigger_id AS Utf8;" +
-                "UPSERT INTO ${config.ydbUserTable} (chat_id, name, is_scheduled, translate_lang_code, trigger_id) " +
-                "VALUES (\$chat_id, \$name, \$is_scheduled, \$translate_lang_code, \$trigger_id)"
+                "UPSERT INTO ${config.ydbUserTable} (chat_id, name, schedule_state, translate_lang_code, trigger_id) " +
+                "VALUES (\$chat_id, \$name, \$schedule_state, \$translate_lang_code, \$trigger_id)"
         val params = Params.of(
             "\$chat_id", PrimitiveValue.newUint64(entity.chatId),
             "\$name", PrimitiveValue.newText(entity.name),
-            "\$is_scheduled", PrimitiveValue.newBool(entity.isScheduled),
+            "\$schedule_state", PrimitiveValue.newText(entity.scheduleState.name),
             "\$translate_lang_code", PrimitiveValue.newText(entity.translateLangCode.code),
             "\$trigger_id", PrimitiveValue.newText(entity.triggerId)
         )

--- a/src/main/kotlin/space/maxkonkin/nasapicbot/service/MessageService.kt
+++ b/src/main/kotlin/space/maxkonkin/nasapicbot/service/MessageService.kt
@@ -1,6 +1,7 @@
 package space.maxkonkin.nasapicbot.service
 
 import org.yaml.snakeyaml.Yaml
+import space.maxkonkin.nasapicbot.model.ScheduleState
 import java.io.InputStream
 
 class MessageService {
@@ -28,8 +29,8 @@ class MessageService {
         return current as? String ?: "Message not found: $key"
     }
     
-    fun getScheduleMessage(isScheduled: Boolean, locale: String = "ru"): String {
-        val key = if (isScheduled) "schedule.updated_on" else "schedule.updated_off"
+    fun getScheduleMessage(scheduleState: ScheduleState, locale: String = "ru"): String {
+        val key = if (scheduleState == ScheduleState.ACTIVE) "schedule.updated_on" else "schedule.updated_off"
         return getMessage(key, locale)
     }
     

--- a/src/main/kotlin/space/maxkonkin/nasapicbot/service/UserService.kt
+++ b/src/main/kotlin/space/maxkonkin/nasapicbot/service/UserService.kt
@@ -2,6 +2,7 @@ package space.maxkonkin.nasapicbot.service
 
 import org.slf4j.LoggerFactory
 import space.maxkonkin.nasapicbot.client.YandexCloudClient
+import space.maxkonkin.nasapicbot.model.ScheduleState
 import space.maxkonkin.nasapicbot.model.Token
 import space.maxkonkin.nasapicbot.model.User
 import space.maxkonkin.nasapicbot.repository.UserRepository
@@ -38,22 +39,26 @@ class UserService(
         repository.update(user)
     }
 
-    fun updateSchedule(user: User, token: Token?) {
-        log.info("updating user schedule with chat_id={}", user.chatId)
-        if (token != null ) {
-            if (cloudClient.isTriggerCreated(user.triggerId, token.token)) {
-                if (user.isScheduled) {
+    fun toggleSchedule(user: User, token: Token?): ScheduleState {
+        log.info("toggling schedule for user with chat_id={}", user.chatId)
+        val newState = user.scheduleState.toggle()
+        if (token != null) {
+            when (newState) {
+                ScheduleState.ACTIVE -> if (user.triggerId != null) {
                     cloudClient.resumeTrigger(user.triggerId, token.token)
+                    repository.update(user.copy(scheduleState = newState))
                 } else {
-                    cloudClient.pauseTrigger(user.triggerId, token.token)
+                    val triggerId = cloudClient.createTrigger(user.chatId.toString(), token.token)
+                    repository.update(user.copy(scheduleState = newState, triggerId = triggerId))
                 }
-                repository.update(user)
-            } else {
-                val triggerId = cloudClient.createTrigger(user.chatId.toString(), token.token)
-                if (user.isScheduled.not()) cloudClient.pauseTrigger(triggerId, token.token)
-                repository.update(user.copy(triggerId = triggerId))
+                ScheduleState.PAUSED -> {
+                    cloudClient.pauseTrigger(requireNotNull(user.triggerId), token.token)
+                    repository.update(user.copy(scheduleState = newState))
+                }
+                ScheduleState.NONE -> {}
             }
         }
+        return newState
     }
 
     fun delete(user: User, token: Token) {

--- a/src/main/kotlin/space/maxkonkin/nasapicbot/web/NASAPicOnSpringBot.kt
+++ b/src/main/kotlin/space/maxkonkin/nasapicbot/web/NASAPicOnSpringBot.kt
@@ -5,7 +5,9 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage
 import org.telegram.telegrambots.meta.api.objects.Update
 import org.telegram.telegrambots.webhook.TelegramWebhookBot
 import space.maxkonkin.nasapicbot.exception.UserNotFoundException
+import space.maxkonkin.nasapicbot.model.BotCommand
 import space.maxkonkin.nasapicbot.model.LangCode
+import space.maxkonkin.nasapicbot.model.ScheduleState
 import space.maxkonkin.nasapicbot.model.Token
 import space.maxkonkin.nasapicbot.model.User
 import space.maxkonkin.nasapicbot.service.MessageService
@@ -13,9 +15,6 @@ import space.maxkonkin.nasapicbot.service.NasaService
 import space.maxkonkin.nasapicbot.service.UserService
 import space.maxkonkin.nasapicbot.to.NasaTo
 import space.maxkonkin.nasapicbot.util.getFormattedMessage
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import java.util.regex.Pattern
 
 class NASAPicOnSpringBot(
     private val nasaService: NasaService,
@@ -43,87 +42,37 @@ class NASAPicOnSpringBot(
         return botPath
     }
 
-    private fun stripBotNameFromCommand(command: String): String {
-        if (command.contains("@")) {
-            val atIndex = command.indexOf('@')
-            val botNameInCommand = command.substring(atIndex + 1)
-            if (botNameInCommand.equals(botName, ignoreCase = true)) {
-                return command.substring(0, atIndex)
-            }
-        }
-        return command
-    }
-
     fun handleUpdate(update: Update, token: Token?): SendMessage? {
-        if (update.hasCallbackQuery().not()) {
-            if (update.hasMessage()) {
-                val message = update.message
-                val chatId = message.chatId
-                val tgUser = message.from
-                val newUser = User(chatId, tgUser.userName, false, LangCode.EN)
-                userService.saveNew(newUser)
-                val user =
-                    userService.getById(chatId) ?: throw UserNotFoundException("user with chat_id=$chatId not found")
-                val text = message.text
-                val regex = "\\d{4}-\\d{2}-\\d{2}"
-                val pattern = Pattern.compile(regex)
-                val matcher = pattern.matcher(checkNotNull(text))
-                if (matcher.find()) {
-                    val fromRegex = matcher.group(0)
-                    return try {
-                        val date = LocalDate.parse(fromRegex, DateTimeFormatter.ISO_LOCAL_DATE)
-                        if (!date.isBefore(LocalDate.of(1995, 6, 20)) &&
-                            !date.isAfter(LocalDate.now())
-                        ) {
-                            givePostedOnDatePicture(date, user)
-                        } else {
-                            sendMessage(
-                                messageService.getMessage("error.invalid_date_range", user.locale()),
-                                chatId
-                            )
-                        }
-                    } catch (e: Exception) {
-                        System.err.println("Parsing error! " + e.message)
-                        sendMessage(messageService.getMessage("error.invalid_date_format", user.locale()), chatId)
-                    }
-                } else {
-                    val processedText = stripBotNameFromCommand(text)
-                    return when (processedText) {
-                        "/start", "/help" -> {
-                            sendMessage(messageService.getMessage("help.text", user.locale()), chatId)
-                        }
+        if (update.hasCallbackQuery()) return null
+        if (!update.hasMessage()) return null
 
-                        "/today" -> {
-                            giveTodayPicture(user)
-                        }
+        val message = update.message
+        val chatId = message.chatId
+        val newUser = User(chatId, message.from.userName, ScheduleState.NONE, LangCode.EN)
+        userService.saveNew(newUser)
+        val user = userService.getById(chatId)
+            ?: throw UserNotFoundException("user with chat_id=$chatId not found")
 
-                        "/random" -> {
-                            giveRandomPicture(user)
-                        }
+        return when (val cmd = BotCommand.parse(checkNotNull(message.text), botName, message.isReply)) {
+            is BotCommand.Start, BotCommand.Help ->
+                sendMessage(messageService.getMessage("help.text", user.locale()), chatId)
 
-                        "/schedule" -> {
-                            toggleSchedule(user, token)
-                        }
+            is BotCommand.Today -> giveTodayPicture(user)
+            is BotCommand.Random -> giveRandomPicture(user)
+            is BotCommand.Schedule -> toggleSchedule(user, token)
+            is BotCommand.Translate -> toggleTranslate(user)
+            is BotCommand.OnDate -> givePostedOnDatePicture(cmd.date, user)
+            is BotCommand.InvalidDateRange ->
+                sendMessage(messageService.getMessage("error.invalid_date_range", user.locale()), chatId)
 
-                        "/translate" -> {
-                            toggleTranslate(user)
-                        }
+            is BotCommand.InvalidDateFormat ->
+                sendMessage(messageService.getMessage("error.invalid_date_format", user.locale()), chatId)
 
-                        else -> {
-                            if (update.message.isReply.not())
-                                sendMessage(
-                                    messageService.getMessage(
-                                        "error.unsupported_command",
-                                        user.locale()
-                                    ), chatId
-                                )
-                            else null
-                        }
-                    }
-                }
-            }
+            is BotCommand.Unknown ->
+                sendMessage(messageService.getMessage("error.unsupported_command", user.locale()), chatId)
+
+            is BotCommand.Reply -> null
         }
-        return null
     }
 
     private fun giveRandomPicture(user: User): SendMessage {
@@ -136,25 +85,21 @@ class NASAPicOnSpringBot(
         return sendFormattedMessage(user, requireNotNull(today) { "Unable to send message" }, user.chatId)
     }
 
-    private fun givePostedOnDatePicture(date: LocalDate, user: User): SendMessage {
+    private fun givePostedOnDatePicture(date: java.time.LocalDate, user: User): SendMessage {
         val onDate = nasaService.getOnDate(date, user)
         return sendFormattedMessage(user, requireNotNull(onDate) { "Unable to send message" }, user.chatId)
     }
 
     private fun toggleSchedule(user: User, token: Token?): SendMessage {
-        val isScheduled = !user.isScheduled
-        userService.updateSchedule(user.copy(isScheduled = isScheduled), token)
-        return sendMessage(messageService.getScheduleMessage(isScheduled, user.locale()), user.chatId)
+        val newState = userService.toggleSchedule(user, token)
+        return sendMessage(messageService.getScheduleMessage(newState, user.locale()), user.chatId)
     }
 
-    private fun toggleTranslate(
-        user: User,
-        targetLang: LangCode = LangCode.RU
-    ): SendMessage {
+    private fun toggleTranslate(user: User): SendMessage {
         val updatedUser = if (user.translateLangCode != LangCode.EN) {
             user.copy(translateLangCode = LangCode.EN)
         } else {
-            user.copy(translateLangCode = targetLang)
+            user.copy(translateLangCode = LangCode.RU)
         }
         userService.update(updatedUser)
         val isEnabled = updatedUser.translateLangCode != LangCode.EN
@@ -169,15 +114,12 @@ class NASAPicOnSpringBot(
     }
 
     private fun sendMessage(messageText: String, chatId: Long): SendMessage {
-        val message = SendMessage.builder()
+        return SendMessage.builder()
             .parseMode("HTML")
             .chatId(chatId)
             .text(messageText)
             .build()
-        return message
     }
 
-    private fun User.locale(): String {
-        return translateLangCode.code
-    }
+    private fun User.locale(): String = translateLangCode.code
 }

--- a/src/main/kotlin/space/maxkonkin/nasapicbot/web/TimerHandler.kt
+++ b/src/main/kotlin/space/maxkonkin/nasapicbot/web/TimerHandler.kt
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import space.maxkonkin.nasapicbot.config.bot
+import space.maxkonkin.nasapicbot.model.ScheduleState
 import space.maxkonkin.nasapicbot.model.TimerMessage
 import space.maxkonkin.nasapicbot.service.UserService
 import java.io.IOException
@@ -32,7 +33,7 @@ fun handle(timerMessage: TimerMessage): String {
         log.debug("Payload: {}", payload)
         val user = userService.getById(payload.toLong())
         if (user != null) {
-            if (user.isScheduled) {
+            if (user.scheduleState == ScheduleState.ACTIVE) {
                 val sendMessage = nasaPicOnSpringBot.giveTodayPicture(user)
                 telegramClient.execute(sendMessage)
                 log.info("Message sent to chat_id={}", sendMessage.chatId)

--- a/src/test/kotlin/space/maxkonkin/nasapicbot/NASAPicOnSpringBotTest.kt
+++ b/src/test/kotlin/space/maxkonkin/nasapicbot/NASAPicOnSpringBotTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.telegram.telegrambots.meta.api.objects.message.Message
 import org.telegram.telegrambots.meta.api.objects.Update
 import space.maxkonkin.nasapicbot.model.LangCode
+import space.maxkonkin.nasapicbot.model.ScheduleState
 import space.maxkonkin.nasapicbot.model.User
 import space.maxkonkin.nasapicbot.service.MessageService
 import space.maxkonkin.nasapicbot.service.NasaService
@@ -27,7 +28,7 @@ class NASAPicOnSpringBotTest {
         botName = "TestBot"
     )
 
-    private val domainUser = User(100L, "testUser", false, LangCode.EN)
+    private val domainUser = User(100L, "testUser", ScheduleState.NONE, LangCode.EN)
     private val nasaTo = NasaTo(
         null, null, "2024-01-15", "Explanation",
         "https://hd.url", "image", "v1", "Title", "https://img.url"
@@ -126,15 +127,15 @@ class NASAPicOnSpringBotTest {
     }
 
     @Test
-    fun `schedule command toggles isScheduled from false to true and returns message`() {
-        every { userService.updateSchedule(any(), null) } just Runs
-        every { messageService.getScheduleMessage(true, "en") } returns "Schedule: on"
+    fun `schedule command toggles NONE to ACTIVE and returns enabled message`() {
+        every { userService.toggleSchedule(domainUser, null) } returns ScheduleState.ACTIVE
+        every { messageService.getScheduleMessage(ScheduleState.ACTIVE, "en") } returns "Schedule: on"
 
         val result = bot.handleUpdate(buildUpdate("/schedule"), null)
 
         assertNotNull(result)
         assertEquals("Schedule: on", result.text)
-        verify { userService.updateSchedule(domainUser.copy(isScheduled = true), null) }
+        verify { userService.toggleSchedule(domainUser, null) }
     }
 
     @Test

--- a/src/test/kotlin/space/maxkonkin/nasapicbot/UserServiceTest.kt
+++ b/src/test/kotlin/space/maxkonkin/nasapicbot/UserServiceTest.kt
@@ -2,8 +2,10 @@ package space.maxkonkin.nasapicbot
 
 import io.mockk.*
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 import space.maxkonkin.nasapicbot.client.YandexCloudClient
 import space.maxkonkin.nasapicbot.model.LangCode
+import space.maxkonkin.nasapicbot.model.ScheduleState
 import space.maxkonkin.nasapicbot.model.Token
 import space.maxkonkin.nasapicbot.model.User
 import space.maxkonkin.nasapicbot.repository.UserRepository
@@ -15,7 +17,7 @@ class UserServiceTest {
     private val cloudClient = mockk<YandexCloudClient>()
     private val userService = UserService(repository, cloudClient)
 
-    private val testUser = User(123L, "testUser", false, LangCode.EN)
+    private val testUser = User(123L, "testUser", ScheduleState.NONE, LangCode.EN)
     private val token = Token("test-token", 3600L, "Bearer")
 
     // --- saveNew ---
@@ -39,71 +41,58 @@ class UserServiceTest {
         verify(exactly = 0) { repository.save(any()) }
     }
 
-    // --- updateSchedule ---
+    // --- toggleSchedule ---
 
     @Test
-    fun `updateSchedule does nothing when token is null`() {
-        userService.updateSchedule(testUser, null)
+    fun `toggleSchedule does nothing with cloud when token is null`() {
+        val result = userService.toggleSchedule(testUser, null)
 
-        verify(exactly = 0) { cloudClient.isTriggerCreated(any(), any()) }
+        assertEquals(ScheduleState.ACTIVE, result)
+        verify(exactly = 0) { cloudClient.createTrigger(any(), any()) }
         verify(exactly = 0) { repository.update(any()) }
     }
 
     @Test
-    fun `updateSchedule resumes existing trigger when isScheduled is true`() {
-        val scheduledUser = testUser.copy(isScheduled = true, triggerId = "trigger-1")
-        every { cloudClient.isTriggerCreated("trigger-1", "test-token") } returns true
-        every { cloudClient.resumeTrigger("trigger-1", "test-token") } returns true
-        every { repository.update(scheduledUser) } just Runs
+    fun `toggleSchedule NONE to ACTIVE creates trigger`() {
+        val noneUser = testUser.copy(scheduleState = ScheduleState.NONE, triggerId = null)
+        every { cloudClient.createTrigger("123", "test-token") } returns "new-trigger-id"
+        every { repository.update(noneUser.copy(scheduleState = ScheduleState.ACTIVE, triggerId = "new-trigger-id")) } just Runs
 
-        userService.updateSchedule(scheduledUser, token)
+        val result = userService.toggleSchedule(noneUser, token)
 
-        verify { cloudClient.resumeTrigger("trigger-1", "test-token") }
-        verify { repository.update(scheduledUser) }
+        assertEquals(ScheduleState.ACTIVE, result)
+        verify { cloudClient.createTrigger("123", "test-token") }
+        verify { repository.update(noneUser.copy(scheduleState = ScheduleState.ACTIVE, triggerId = "new-trigger-id")) }
         verify(exactly = 0) { cloudClient.pauseTrigger(any(), any()) }
-    }
-
-    @Test
-    fun `updateSchedule pauses existing trigger when isScheduled is false`() {
-        val unscheduledUser = testUser.copy(isScheduled = false, triggerId = "trigger-1")
-        every { cloudClient.isTriggerCreated("trigger-1", "test-token") } returns true
-        every { cloudClient.pauseTrigger("trigger-1", "test-token") } returns true
-        every { repository.update(unscheduledUser) } just Runs
-
-        userService.updateSchedule(unscheduledUser, token)
-
-        verify { cloudClient.pauseTrigger("trigger-1", "test-token") }
-        verify { repository.update(unscheduledUser) }
         verify(exactly = 0) { cloudClient.resumeTrigger(any(), any()) }
     }
 
     @Test
-    fun `updateSchedule creates trigger without pausing when isScheduled is true`() {
-        val scheduledUser = testUser.copy(isScheduled = true, triggerId = null)
-        every { cloudClient.isTriggerCreated(null, "test-token") } returns false
-        every { cloudClient.createTrigger("123", "test-token") } returns "new-trigger-id"
-        every { repository.update(scheduledUser.copy(triggerId = "new-trigger-id")) } just Runs
+    fun `toggleSchedule ACTIVE to PAUSED pauses existing trigger`() {
+        val activeUser = testUser.copy(scheduleState = ScheduleState.ACTIVE, triggerId = "trigger-1")
+        every { cloudClient.pauseTrigger("trigger-1", "test-token") } returns true
+        every { repository.update(activeUser.copy(scheduleState = ScheduleState.PAUSED)) } just Runs
 
-        userService.updateSchedule(scheduledUser, token)
+        val result = userService.toggleSchedule(activeUser, token)
 
-        verify { cloudClient.createTrigger("123", "test-token") }
-        verify { repository.update(scheduledUser.copy(triggerId = "new-trigger-id")) }
-        verify(exactly = 0) { cloudClient.pauseTrigger(any(), any()) }
+        assertEquals(ScheduleState.PAUSED, result)
+        verify { cloudClient.pauseTrigger("trigger-1", "test-token") }
+        verify { repository.update(activeUser.copy(scheduleState = ScheduleState.PAUSED)) }
+        verify(exactly = 0) { cloudClient.resumeTrigger(any(), any()) }
     }
 
     @Test
-    fun `updateSchedule creates and immediately pauses trigger when isScheduled is false`() {
-        val unscheduledUser = testUser.copy(isScheduled = false, triggerId = null)
-        every { cloudClient.isTriggerCreated(null, "test-token") } returns false
-        every { cloudClient.createTrigger("123", "test-token") } returns "new-trigger-id"
-        every { cloudClient.pauseTrigger("new-trigger-id", "test-token") } returns true
-        every { repository.update(unscheduledUser.copy(triggerId = "new-trigger-id")) } just Runs
+    fun `toggleSchedule PAUSED to ACTIVE resumes existing trigger`() {
+        val pausedUser = testUser.copy(scheduleState = ScheduleState.PAUSED, triggerId = "trigger-1")
+        every { cloudClient.resumeTrigger("trigger-1", "test-token") } returns true
+        every { repository.update(pausedUser.copy(scheduleState = ScheduleState.ACTIVE)) } just Runs
 
-        userService.updateSchedule(unscheduledUser, token)
+        val result = userService.toggleSchedule(pausedUser, token)
 
-        verify { cloudClient.createTrigger("123", "test-token") }
-        verify { cloudClient.pauseTrigger("new-trigger-id", "test-token") }
-        verify { repository.update(unscheduledUser.copy(triggerId = "new-trigger-id")) }
+        assertEquals(ScheduleState.ACTIVE, result)
+        verify { cloudClient.resumeTrigger("trigger-1", "test-token") }
+        verify { repository.update(pausedUser.copy(scheduleState = ScheduleState.ACTIVE)) }
+        verify(exactly = 0) { cloudClient.pauseTrigger(any(), any()) }
     }
 
     // --- delete ---

--- a/src/test/kotlin/space/maxkonkin/nasapicbot/model/BotCommandTest.kt
+++ b/src/test/kotlin/space/maxkonkin/nasapicbot/model/BotCommandTest.kt
@@ -1,0 +1,67 @@
+package space.maxkonkin.nasapicbot.model
+
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class BotCommandTest {
+
+    private fun parse(text: String, isReply: Boolean = false) =
+        BotCommand.parse(text, botName = "NasaBot", isReply = isReply)
+
+    @Test
+    fun `slash commands are parsed correctly`() {
+        assertIs<BotCommand.Start>(parse("/start"))
+        assertIs<BotCommand.Help>(parse("/help"))
+        assertIs<BotCommand.Today>(parse("/today"))
+        assertIs<BotCommand.Random>(parse("/random"))
+        assertIs<BotCommand.Schedule>(parse("/schedule"))
+        assertIs<BotCommand.Translate>(parse("/translate"))
+    }
+
+    @Test
+    fun `bot name suffix is stripped`() {
+        assertIs<BotCommand.Start>(parse("/start@NasaBot"))
+        assertIs<BotCommand.Help>(parse("/help@NasaBot"))
+    }
+
+    @Test
+    fun `unknown command returns Unknown`() {
+        assertIs<BotCommand.Unknown>(parse("/foo"))
+    }
+
+    @Test
+    fun `reply with unknown command returns Reply`() {
+        assertIs<BotCommand.Reply>(parse("/unknown", isReply = true))
+    }
+
+    @Test
+    fun `valid date in APOD range returns OnDate`() {
+        val cmd = parse("2024-06-15")
+        assertIs<BotCommand.OnDate>(cmd)
+        assertEquals(LocalDate.of(2024, 6, 15), cmd.date)
+    }
+
+    @Test
+    fun `date before APOD launch returns InvalidDateRange`() {
+        assertIs<BotCommand.InvalidDateRange>(parse("1995-01-01"))
+    }
+
+    @Test
+    fun `future date returns InvalidDateRange`() {
+        assertIs<BotCommand.InvalidDateRange>(parse("2099-12-31"))
+    }
+
+    @Test
+    fun `impossible calendar date returns InvalidDateFormat`() {
+        assertIs<BotCommand.InvalidDateFormat>(parse("2024-99-99"))
+    }
+
+    @Test
+    fun `APOD first day is valid`() {
+        val cmd = parse("1995-06-20")
+        assertIs<BotCommand.OnDate>(cmd)
+        assertEquals(LocalDate.of(1995, 6, 20), cmd.date)
+    }
+}

--- a/src/test/kotlin/space/maxkonkin/nasapicbot/service/MessageServiceTest.kt
+++ b/src/test/kotlin/space/maxkonkin/nasapicbot/service/MessageServiceTest.kt
@@ -1,6 +1,7 @@
 package space.maxkonkin.nasapicbot.service
 
 import org.junit.jupiter.api.Test
+import space.maxkonkin.nasapicbot.model.ScheduleState
 import kotlin.test.assertEquals
 
 class MessageServiceTest {
@@ -26,10 +27,10 @@ class MessageServiceTest {
     fun testGetScheduleMessage() {
         val messageService = MessageService()
         
-        val scheduleOn = messageService.getScheduleMessage(true, "ru")
+        val scheduleOn = messageService.getScheduleMessage(ScheduleState.ACTIVE, "ru")
         assertEquals("Отправка по расписанию: вкл", scheduleOn)
-        
-        val scheduleOff = messageService.getScheduleMessage(false, "ru")
+
+        val scheduleOff = messageService.getScheduleMessage(ScheduleState.PAUSED, "ru")
         assertEquals("Отправка по расписанию: выкл", scheduleOff)
     }
     

--- a/src/test/kotlin/space/maxkonkin/nasapicbot/service/NasaServiceTest.kt
+++ b/src/test/kotlin/space/maxkonkin/nasapicbot/service/NasaServiceTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import space.maxkonkin.nasapicbot.client.NasaApiClient
 import space.maxkonkin.nasapicbot.model.LangCode
 import space.maxkonkin.nasapicbot.model.Nasa
+import space.maxkonkin.nasapicbot.model.ScheduleState
 import space.maxkonkin.nasapicbot.model.User
 import space.maxkonkin.nasapicbot.repository.NasaRowTableRepository
 import space.maxkonkin.nasapicbot.to.NasaTo
@@ -19,8 +20,8 @@ class NasaServiceTest {
     private val nasaRepository = mockk<NasaRowTableRepository>()
     private val translateService = mockk<TranslateService>()
 
-    private val enUser = User(1L, "user", false, LangCode.EN)
-    private val ruUser = User(2L, "user", false, LangCode.RU)
+    private val enUser = User(1L, "user", ScheduleState.NONE, LangCode.EN)
+    private val ruUser = User(2L, "user", ScheduleState.NONE, LangCode.RU)
 
     private val nasaTo = NasaTo(
         credit = null,


### PR DESCRIPTION
## Summary
- Refactored bot command handling into a sealed `BotCommand` state machine,
  replacing ad-hoc string matching in `NASAPicOnSpringBot`
- Added `BotCommand` and `ScheduleState` models; updated `User`, `UserService`,
  `UserRepository`, and `MessageService` accordingly
- Fixed README: correct language (Kotlin/Koin), commands (/today, /schedule,
  /translate, date input), deployment runtime (kotlin20), memory, env vars,
  TimerHandler step, and step numbering
## Test plan
- [ ] Unit tests pass (BotCommandTest, UserServiceTest, NASAPicOnSpringBotTest,
      MessageServiceTest, NasaServiceTest)
- [ ] Bot responds correctly to /today, /random, /schedule, /translate, date input
- [ ] TimerHandler still fires scheduled posts